### PR TITLE
feat: Add custom API URL support for Telegram Bot proxy configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "cunzhi"
-version = "0.2.1"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/src/frontend/components/settings/TelegramSettings.vue
+++ b/src/frontend/components/settings/TelegramSettings.vue
@@ -8,6 +8,7 @@ interface TelegramConfig {
   bot_token: string
   chat_id: string
   hide_frontend_popup: boolean
+  api_base_url: string
 }
 
 const emit = defineEmits(['telegramConfigChange'])
@@ -21,6 +22,7 @@ const telegramConfig = ref<TelegramConfig>({
   bot_token: '',
   chat_id: '',
   hide_frontend_popup: false,
+  api_base_url: 'https://api.telegram.org/bot',
 })
 
 // 测试状态
@@ -279,6 +281,33 @@ onMounted(() => {
             </div>
           </div>
 
+          <!-- API服务器URL设置 -->
+          <div class="pt-4 border-t border-gray-200 dark:border-gray-700">
+            <div class="flex items-start">
+              <div class="w-1.5 h-1.5 bg-info rounded-full mr-3 mt-2 flex-shrink-0" />
+              <div class="flex-1">
+                <div class="text-sm font-medium mb-3 leading-relaxed">
+                  API服务器URL
+                </div>
+                <div class="text-xs opacity-60 mb-3">
+                  Telegram Bot API服务器地址。默认使用官方API，如需使用代理或自建服务器请修改此URL
+                </div>
+                <n-space vertical size="small">
+                  <n-input
+                    v-model:value="telegramConfig.api_base_url" type="text"
+                    placeholder="https://api.telegram.org/bot" size="small"
+                    :disabled="isTesting" @blur="saveTelegramConfig"
+                  />
+                  <div class="text-xs text-gray-500 dark:text-gray-400">
+                    💡 常用代理服务器：
+                    <br>• 官方API: https://api.telegram.org/bot
+                    <br>• 自建代理: https://your-proxy.com/bot
+                  </div>
+                </n-space>
+              </div>
+            </div>
+          </div>
+
           <!-- 隐藏前端弹窗设置 -->
           <div class="pt-4 border-t border-gray-200 dark:border-gray-700">
             <div class="flex items-center justify-between">
@@ -406,7 +435,7 @@ onMounted(() => {
             <div class="text-sm space-y-2">
               <div class="p-2 rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800">
                 <code class="text-xs break-all text-gray-700 dark:text-gray-300">
-                  https://api.telegram.org/bot{{ telegramConfig.bot_token || 'YOUR_BOT_TOKEN' }}/getUpdates
+                  {{ telegramConfig.api_base_url }}{{ telegramConfig.bot_token || 'YOUR_BOT_TOKEN' }}/getUpdates
                 </code>
               </div>
             </div>

--- a/src/rust/config/settings.rs
+++ b/src/rust/config/settings.rs
@@ -97,6 +97,8 @@ pub struct TelegramConfig {
     pub chat_id: String, // Chat ID
     #[serde(default = "default_telegram_hide_frontend_popup")]
     pub hide_frontend_popup: bool, // 是否隐藏前端弹窗，仅使用Telegram交互
+    #[serde(default = "default_telegram_api_base_url")]
+    pub api_base_url: String, // Telegram API基础URL
 }
 
 #[derive(Debug)]
@@ -154,6 +156,7 @@ pub fn default_telegram_config() -> TelegramConfig {
         bot_token: default_telegram_bot_token(),
         chat_id: default_telegram_chat_id(),
         hide_frontend_popup: default_telegram_hide_frontend_popup(),
+        api_base_url: default_telegram_api_base_url(),
     }
 }
 
@@ -277,6 +280,10 @@ pub fn default_telegram_chat_id() -> String {
 
 pub fn default_telegram_hide_frontend_popup() -> bool {
     telegram::DEFAULT_HIDE_FRONTEND_POPUP
+}
+
+pub fn default_telegram_api_base_url() -> String {
+    telegram::API_BASE_URL.to_string()
 }
 
 impl WindowConfig {

--- a/src/rust/telegram/integration.rs
+++ b/src/rust/telegram/integration.rs
@@ -24,7 +24,12 @@ pub struct TelegramIntegration {
 impl TelegramIntegration {
     /// 创建新的Telegram集成实例
     pub fn new(bot_token: String, chat_id: String, app_handle: AppHandle) -> Result<Self> {
-        let core = TelegramCore::new(bot_token, chat_id)?;
+        Self::new_with_api_url(bot_token, chat_id, app_handle, None)
+    }
+
+    /// 创建新的Telegram集成实例，支持自定义API URL
+    pub fn new_with_api_url(bot_token: String, chat_id: String, app_handle: AppHandle, api_url: Option<String>) -> Result<Self> {
+        let core = TelegramCore::new_with_api_url(bot_token, chat_id, api_url)?;
 
         Ok(Self {
             core,

--- a/src/rust/telegram/mcp_handler.rs
+++ b/src/rust/telegram/mcp_handler.rs
@@ -27,10 +27,17 @@ pub async fn handle_telegram_only_mcp_request(request_file: &str) -> Result<()> 
         return Ok(());
     }
 
-    // 创建Telegram核心实例
-    let core = TelegramCore::new(
+    // 创建Telegram核心实例，使用配置中的API URL
+    let api_url = if telegram_config.api_base_url == crate::constants::telegram::API_BASE_URL {
+        None
+    } else {
+        Some(telegram_config.api_base_url.clone())
+    };
+
+    let core = TelegramCore::new_with_api_url(
         telegram_config.bot_token.clone(),
         telegram_config.chat_id.clone(),
+        api_url,
     )?;
 
     // 发送消息到Telegram


### PR DESCRIPTION
## 🚀 功能描述
为Telegram Bot添加自定义API URL支持，允许用户配置代理服务器或自建API服务器。

## ✨ 新增功能
- ✅ 支持自定义Telegram Bot API服务器URL
- ✅ 前端UI新增API服务器URL配置选项
- ✅ 保持向后兼容，默认使用官方API
- ✅ 支持代理服务器配置
- ✅ 配置持久化存储

## 🔧 技术实现
- 在`TelegramConfig`中添加`api_base_url`字段
- 使用teloxide的`set_api_url`方法设置自定义API服务器
- 更新前端界面提供配置选项
- 更新所有相关模块以支持自定义API URL

## 🧪 测试状态
- ✅ 编译通过
- ✅ 功能测试正常
- ✅ 向后兼容性验证通过

## 📸 截图
（如果有UI变更的截图可以在这里添加）

## 🎯 使用场景
- 网络受限环境下通过代理访问Telegram API
- 使用自建Telegram Bot API服务器
- 提高API访问稳定性和速度
