### PR TITLE
Fix Ubuntu 24 compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install system dependencies (Linux)
-        if: matrix.platform == 'ubuntu-20.04'
+        if: startsWith(matrix.platform, 'ubuntu-')
         run: |
           sudo apt-get update
           sudo apt-get install -y \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           - platform: macos-latest
             args: --target x86_64-apple-darwin
             name: macos-x86_64
-          - platform: ubuntu-22.04
+          - platform: ubuntu-20.04
             args: ''
             name: linux-x86_64
           - platform: windows-latest
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install system dependencies (Linux)
-        if: matrix.platform == 'ubuntu-22.04'
+        if: matrix.platform == 'ubuntu-20.04'
         run: |
           sudo apt-get update
           sudo apt-get install -y \


### PR DESCRIPTION
Fixes #20

## 问题描述
修复 Ubuntu 24 中 GTK 初始化失败的兼容性问题。

## 解决方案
- 将 CI 构建平台从 ubuntu-22.04 改为 ubuntu-20.04
- 使用更通用的平台检查条件
- 提高对新版本 Ubuntu 的兼容性

## 技术原理
Ubuntu 20.04 构建的二进制文件具有更好的向前兼容性，避免 GTK 库版本不匹配问题。