### PR TITLE
fix: 采用单实例模式并监听窗口焦点，解决多开时配置不同步的问题

### DIFF
--- a/src/frontend/App.vue
+++ b/src/frontend/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, watchEffect } from 'vue'
+import { onMounted, onUnmounted, watchEffect } from 'vue'
 import AppContent from './components/AppContent.vue'
 import { useAppManager } from './composables/useAppManager'
 import { useEventHandlers } from './composables/useEventHandlers'
@@ -38,6 +38,11 @@ onMounted(async () => {
   catch (error) {
     console.error('应用初始化失败:', error)
   }
+})
+
+// 清理
+onUnmounted(() => {
+  actions.app.cleanup()
 })
 </script>
 

--- a/src/frontend/components/popup/PopupHeader.vue
+++ b/src/frontend/components/popup/PopupHeader.vue
@@ -36,8 +36,6 @@ function handleOpenMainLayout() {
 function handleToggleAlwaysOnTop() {
   emit('toggleAlwaysOnTop')
 }
-
-
 </script>
 
 <template>

--- a/src/frontend/components/settings/WindowSettings.vue
+++ b/src/frontend/components/settings/WindowSettings.vue
@@ -37,6 +37,7 @@ const currentHeight = ref(0)
 let windowResizeUnlisten: (() => void) | null = null
 
 // 监听props变化，同步本地值
+
 watch(() => props.windowWidth, (newWidth) => {
   localWidth.value = newWidth
 })

--- a/src/frontend/components/tabs/SettingsTab.vue
+++ b/src/frontend/components/tabs/SettingsTab.vue
@@ -132,8 +132,6 @@ function handleWindowSizeUpdate(size: { width: number, height: number, fixed: bo
         </div>
       </n-collapse-item>
 
-
-
       <!-- 字体设置 -->
       <n-collapse-item name="font">
         <template #header>

--- a/src/frontend/composables/useAppInitialization.ts
+++ b/src/frontend/composables/useAppInitialization.ts
@@ -56,12 +56,16 @@ export function useAppInitialization(mcpHandler: ReturnType<typeof import('./use
       await settings.loadWindowSettings()
       await settings.loadWindowConfig()
 
+      // 设置窗口焦点监听器，用于配置同步
+      await settings.setupWindowFocusListener()
+
       // 在MCP模式下，确保前端状态与后端窗口状态同步
       if (isMcp) {
         console.log('MCP模式检测到，同步窗口状态...')
         try {
           await settings.syncWindowStateFromBackend()
-        } catch (error) {
+        }
+        catch (error) {
           console.warn('MCP模式状态同步失败，继续初始化:', error)
         }
       }

--- a/src/frontend/composables/useAppManager.ts
+++ b/src/frontend/composables/useAppManager.ts
@@ -18,23 +18,27 @@ export function useAppManager() {
   const appInit = useAppInitialization(mcpHandler)
 
   // 创建统一的配置对象
-  const appConfig = computed(() => ({
-    theme: theme.currentTheme.value,
-    window: {
-      alwaysOnTop: settings.alwaysOnTop.value,
-      width: settings.windowWidth.value,
-      height: settings.windowHeight.value,
-      fixed: settings.fixedWindowSize.value,
-    },
-    audio: {
-      enabled: settings.audioNotificationEnabled.value,
-      url: settings.audioUrl.value,
-    },
-    reply: {
-      enabled: settings.continueReplyEnabled.value,
-      prompt: settings.continuePrompt.value,
-    },
-  }))
+  const appConfig = computed(() => {
+    const config = {
+      theme: theme.currentTheme.value,
+      window: {
+        alwaysOnTop: settings.alwaysOnTop.value,
+        width: settings.windowWidth.value,
+        height: settings.windowHeight.value,
+        fixed: settings.fixedWindowSize.value,
+      },
+      audio: {
+        enabled: settings.audioNotificationEnabled.value,
+        url: settings.audioUrl.value,
+      },
+      reply: {
+        enabled: settings.continueReplyEnabled.value,
+        prompt: settings.continuePrompt.value,
+      },
+    }
+
+    return config
+  })
 
   // 创建统一的操作对象
   const actions = {
@@ -66,6 +70,10 @@ export function useAppManager() {
     // 应用操作
     app: {
       initialize: appInit.initializeApp,
+      cleanup: () => {
+        // 清理窗口焦点监听器
+        settings.removeWindowFocusListener()
+      },
     },
   }
 

--- a/src/rust/app/builder.rs
+++ b/src/rust/app/builder.rs
@@ -22,6 +22,7 @@ pub fn build_tauri_app() -> Builder<tauri::Wry> {
             get_always_on_top,
             set_always_on_top,
             sync_window_state,
+            reload_config,
 
             // 音频命令
             get_audio_notification_enabled,

--- a/src/rust/config/storage.rs
+++ b/src/rust/config/storage.rs
@@ -42,7 +42,7 @@ pub async fn load_config(state: &State<'_, AppState>, app: &AppHandle) -> Result
     let config_path = get_config_path(app)?;
 
     if config_path.exists() {
-        let config_json = fs::read_to_string(config_path)?;
+        let config_json = fs::read_to_string(&config_path)?;
         let mut config: AppConfig = serde_json::from_str(&config_json)?;
 
         // 合并默认快捷键配置，确保新的默认快捷键被添加

--- a/src/rust/ui/commands.rs
+++ b/src/rust/ui/commands.rs
@@ -1,4 +1,4 @@
-use crate::config::{save_config, AppState, ReplyConfig, WindowConfig, CustomPrompt, CustomPromptConfig, ShortcutConfig, ShortcutBinding};
+use crate::config::{save_config, load_config, AppState, ReplyConfig, WindowConfig, CustomPrompt, CustomPromptConfig, ShortcutConfig, ShortcutBinding};
 use crate::constants::{window, ui, validation};
 use crate::mcp::types::{build_continue_response, build_send_response, ImageAttachment, PopupRequest};
 use crate::mcp::handlers::create_tauri_popup;
@@ -69,6 +69,20 @@ pub async fn sync_window_state(
             .set_always_on_top(always_on_top)
             .map_err(|e| format!("同步窗口状态失败: {}", e))?;
     }
+
+    Ok(())
+}
+
+/// 重新加载配置文件到内存
+#[tauri::command]
+pub async fn reload_config(
+    state: State<'_, AppState>,
+    app: tauri::AppHandle,
+) -> Result<(), String> {
+    // 从文件重新加载配置到内存
+    load_config(&state, &app)
+        .await
+        .map_err(|e| format!("重新加载配置失败: {}", e))?;
 
     Ok(())
 }


### PR DESCRIPTION
- 在useAppInitialization中添加窗口焦点监听器，确保在窗口获得焦点时重新加载设置。
- 在useAppManager中添加清理方法，移除窗口焦点监听器以避免内存泄漏。
- 在App.vue中实现onUnmounted钩子，确保组件卸载时进行清理。