### PR TITLE
feat: 支持多Telegram Bot实例和智能会话路由

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint . --fix",
     "tauri": "cargo tauri",
     "tauri:dev": "cargo tauri dev",
-    "tauri:build": "cargo tauri build",
+    "tauri:build": "cargo tauri build && ./scripts/post-build.sh",
     "test:ui": "cd src/frontend/test && vite",
     "test:ui:build": "cd src/frontend/test && vite build"
   },

--- a/src/frontend/components/popup/PopupInput.vue
+++ b/src/frontend/components/popup/PopupInput.vue
@@ -623,9 +623,14 @@ defineExpose({
   <div class="space-y-3">
     <!-- 预定义选项 -->
     <div v-if="!loading && hasOptions" class="space-y-3" data-guide="predefined-options">
-      <h4 class="text-sm font-medium text-white">
-        请选择选项
-      </h4>
+      <div>
+        <h4 class="text-sm font-medium text-white">
+          请选择选项
+        </h4>
+        <div v-if="request?.session_id" class="text-xs opacity-60 mt-1">
+          工作目录: {{ request.session_id }}
+        </div>
+      </div>
       <n-space vertical size="small">
         <div
           v-for="(option, index) in request!.predefined_options"

--- a/src/frontend/components/settings/TelegramSettings.vue
+++ b/src/frontend/components/settings/TelegramSettings.vue
@@ -1,30 +1,74 @@
 <script setup lang="ts">
 import { invoke } from '@tauri-apps/api/core'
 import { listen } from '@tauri-apps/api/event'
-import { useMessage } from 'naive-ui'
-import { onMounted, ref } from 'vue'
+import { open } from '@tauri-apps/plugin-shell'
+import { useMessage, useDialog } from 'naive-ui'
+import { onMounted, ref, computed } from 'vue'
 import { API_BASE_URL, API_EXAMPLES } from '../../constants/telegram'
+
+interface TelegramBotConfig {
+  name: string
+  bot_token: string
+  chat_id: string
+  api_base_url: string
+}
 
 interface TelegramConfig {
   enabled: boolean
-  bot_token: string
-  chat_id: string
   hide_frontend_popup: boolean
-  api_base_url: string
+  bots: TelegramBotConfig[]
+  default_bot: string
 }
 
 const emit = defineEmits(['telegramConfigChange'])
 
-// Naive UI 消息实例
+// Naive UI 实例
 const message = useMessage()
+const dialog = useDialog()
 
 // 配置状态
 const telegramConfig = ref<TelegramConfig>({
   enabled: false,
+  hide_frontend_popup: false,
+  bots: [],
+  default_bot: '',
+})
+
+// Bot 管理状态
+const showBotDialog = ref(false)
+const editingBot = ref<TelegramBotConfig | null>(null)
+const editingBotOriginalName = ref('')
+const botForm = ref<TelegramBotConfig>({
+  name: '',
   bot_token: '',
   chat_id: '',
-  hide_frontend_popup: false,
   api_base_url: API_BASE_URL,
+})
+
+// 会话映射管理
+const showSessionMappingDialog = ref(false)
+const sessionMappings = ref<Record<string, string>>({})
+const newSessionId = ref('')
+const newSessionBotName = ref('')
+
+// 待配置会话管理
+interface PendingSession {
+  session_id: string
+  first_seen: string
+  last_seen: string
+  request_count: number
+}
+const pendingSessions = ref<PendingSession[]>([])
+const showPendingSessionsDialog = ref(false)
+const configuringSession = ref<PendingSession | null>(null)
+const showConfigureDialog = ref(false)
+const configureForm = ref({
+  useExistingBot: false, // 是否使用已有 Bot
+  selectedBotName: '', // 选中的已有 Bot 名称
+  botName: '',
+  botToken: '',
+  chatId: '',
+  apiBaseUrl: API_BASE_URL,
 })
 
 // 测试状态
@@ -34,9 +78,10 @@ const isTesting = ref(false)
 const isDetectingChatId = ref(false)
 const detectedChatInfo = ref<any>(null)
 
-// 设置向导状态
-const showSetupWizard = ref(false)
-const setupStep = ref(1)
+// 计算属性
+const hasDefaultBot = computed(() => {
+  return telegramConfig.value.bots.length > 0 && telegramConfig.value.default_bot
+})
 
 // 加载Telegram配置
 async function loadTelegramConfig() {
@@ -65,17 +110,116 @@ async function saveTelegramConfig() {
 
 // 切换启用状态
 async function toggleTelegramEnabled() {
-  telegramConfig.value.enabled = !telegramConfig.value.enabled
+  // v-model 已经自动更新了值，这里只需要保存
   await saveTelegramConfig()
 }
 
-async function saveAndTest() {
-  if (!telegramConfig.value.bot_token.trim()) {
+// 切换隐藏前端弹窗
+async function toggleHideFrontendPopup() {
+  // v-model 已经自动更新了值，这里只需要保存
+  await saveTelegramConfig()
+}
+
+// Bot 管理函数
+function openAddBotDialog() {
+  editingBot.value = null
+  editingBotOriginalName.value = ''
+  botForm.value = {
+    name: '',
+    bot_token: '',
+    chat_id: '',
+    api_base_url: API_BASE_URL,
+  }
+  showBotDialog.value = true
+}
+
+function openEditBotDialog(bot: TelegramBotConfig) {
+  editingBot.value = bot
+  editingBotOriginalName.value = bot.name
+  botForm.value = { ...bot }
+  showBotDialog.value = true
+}
+
+async function saveBotConfig() {
+  // 验证表单
+  if (!botForm.value.name.trim()) {
+    message.warning('请输入 Bot 名称')
+    return
+  }
+  if (!botForm.value.bot_token.trim()) {
+    message.warning('请输入 Bot Token')
+    return
+  }
+  if (!botForm.value.chat_id.trim()) {
+    message.warning('请输入 Chat ID')
+    return
+  }
+
+  try {
+    if (editingBot.value) {
+      // 更新现有 bot
+      await invoke('update_telegram_bot', {
+        oldName: editingBotOriginalName.value,
+        bot: botForm.value,
+      })
+      message.success('Bot 配置已更新')
+    }
+    else {
+      // 添加新 bot
+      await invoke('add_telegram_bot', { bot: botForm.value })
+      message.success('Bot 配置已添加')
+    }
+
+    // 重新加载配置
+    await loadTelegramConfig()
+    showBotDialog.value = false
+  }
+  catch (error: any) {
+    console.error('保存 Bot 配置失败:', error)
+    message.error(error || '保存 Bot 配置失败')
+  }
+}
+
+function deleteBot(botName: string) {
+  dialog.warning({
+    title: '确认删除',
+    content: `确定要删除 Bot "${botName}" 吗？`,
+    positiveText: '删除',
+    negativeText: '取消',
+    onPositiveClick: async () => {
+      try {
+        await invoke('remove_telegram_bot', { botName })
+        message.success('Bot 已删除')
+        await loadTelegramConfig()
+      }
+      catch (error: any) {
+        console.error('删除 Bot 失败:', error)
+        message.error(error || '删除 Bot 失败')
+      }
+    },
+  })
+}
+
+async function setDefaultBot(botName: string) {
+  try {
+    await invoke('set_default_telegram_bot', { botName })
+    message.success(`已设置 "${botName}" 为默认 Bot`)
+    await loadTelegramConfig()
+  }
+  catch (error: any) {
+    console.error('设置默认 Bot 失败:', error)
+    message.error(error || '设置默认 Bot 失败')
+  }
+}
+
+// 测试 Bot 连接
+async function testBotConnection(bot: TelegramBotConfig) {
+  if (!bot.bot_token.trim()) {
     message.warning('请输入Bot Token')
     return
   }
 
-  if (!telegramConfig.value.chat_id.trim()) {
+  if (!bot.chat_id.trim()) {
     message.warning('请输入Chat ID')
     return
   }
@@ -83,13 +227,9 @@ async function saveAndTest() {
   try {
     isTesting.value = true
 
-    // 先保存配置
-    await saveTelegramConfig()
-
-    // 然后测试连接
     const result = await invoke('test_telegram_connection_cmd', {
-      botToken: telegramConfig.value.bot_token,
-      chatId: telegramConfig.value.chat_id,
+      botToken: bot.bot_token,
+      chatId: bot.chat_id,
     }) as string
 
     message.success(result)
@@ -103,9 +243,9 @@ async function saveAndTest() {
   }
 }
 
-// 自动获取Chat ID
-async function autoGetChatId() {
-  if (!telegramConfig.value.bot_token.trim()) {
+// 自动获取Chat ID（在 Bot 对话框中使用）
+async function autoGetChatIdForBot() {
+  if (!botForm.value.bot_token.trim()) {
     message.warning('请先输入Bot Token')
     return
   }
@@ -113,9 +253,6 @@ async function autoGetChatId() {
   try {
     isDetectingChatId.value = true
     detectedChatInfo.value = null
-
-    // 监听Chat ID检测事件
-    // 使用静态导入的listen函数
 
     // 定义清理函数数组
     const cleanupFunctions: (() => void)[] = []
@@ -130,9 +267,8 @@ async function autoGetChatId() {
       message.success(`检测到Chat ID: ${event.payload.chat_id}`)
       isDetectingChatId.value = false
 
-      // 自动填入Chat ID
-      telegramConfig.value.chat_id = event.payload.chat_id
-      saveTelegramConfig()
+      // 自动填入Chat ID到表单
+      botForm.value.chat_id = event.payload.chat_id
 
       // 清理所有监听器
       cleanupFunctions.forEach(cleanup => cleanup())
@@ -149,7 +285,7 @@ async function autoGetChatId() {
     cleanupFunctions.push(unlistenTimeout)
 
     // 开始自动获取
-    await invoke('auto_get_chat_id', { botToken: telegramConfig.value.bot_token })
+    await invoke('auto_get_chat_id', { botToken: botForm.value.bot_token })
   }
   catch (error) {
     console.error('自动获取Chat ID失败:', error)
@@ -158,21 +294,254 @@ async function autoGetChatId() {
   }
 }
 
-// 开启设置向导
-function startSetupWizard() {
-  showSetupWizard.value = true
-  setupStep.value = 1
+// 加载会话映射
+async function loadSessionMappings() {
+  try {
+    const mappings = await invoke('get_session_bot_mappings') as Record<string, string>
+    sessionMappings.value = mappings
+  }
+  catch (error) {
+    console.error('加载会话映射失败:', error)
+  }
 }
 
-// 关闭设置向导
-function closeSetupWizard() {
-  showSetupWizard.value = false
-  setupStep.value = 1
+// 打开会话映射管理对话框
+function openSessionMappingDialog() {
+  loadSessionMappings()
+  showSessionMappingDialog.value = true
+}
+
+// 添加会话映射
+async function addSessionMapping(sessionId: string, botName: string) {
+  try {
+    await invoke('set_session_bot_mapping', { sessionId, botName })
+    message.success('会话映射已添加')
+    await loadSessionMappings()
+  }
+  catch (error: any) {
+    console.error('添加会话映射失败:', error)
+    message.error(error || '添加会话映射失败')
+  }
+}
+
+// 删除会话映射
+async function removeSessionMapping(sessionId: string) {
+  try {
+    await invoke('remove_session_bot_mapping', { sessionId })
+    message.success('会话映射已删除')
+    await loadSessionMappings()
+  }
+  catch (error: any) {
+    console.error('删除会话映射失败:', error)
+    message.error(error || '删除会话映射失败')
+  }
+}
+
+// 添加新的会话映射
+async function addNewSessionMapping() {
+  if (!newSessionId.value.trim() || !newSessionBotName.value) {
+    message.warning('请填写完整信息')
+    return
+  }
+
+  await addSessionMapping(newSessionId.value.trim(), newSessionBotName.value)
+  newSessionId.value = ''
+  newSessionBotName.value = ''
+}
+
+// 加载待配置会话
+async function loadPendingSessions() {
+  try {
+    const sessions = await invoke('get_pending_sessions') as PendingSession[]
+    pendingSessions.value = sessions
+  }
+  catch (error) {
+    console.error('加载待配置会话失败:', error)
+  }
+}
+
+// 打开待配置会话对话框
+function openPendingSessionsDialog() {
+  loadPendingSessions()
+  showPendingSessionsDialog.value = true
+}
+
+// 开始配置会话
+function startConfigureSession(session: PendingSession) {
+  configuringSession.value = session
+  // 从会话 ID 提取目录名作为默认 bot 名称
+  const pathParts = session.session_id.split('/')
+  const dirName = pathParts[pathParts.length - 1] || pathParts[pathParts.length - 2]
+  configureForm.value.useExistingBot = false
+  configureForm.value.selectedBotName = ''
+  configureForm.value.botName = `${dirName} Bot`
+  configureForm.value.botToken = ''
+  configureForm.value.chatId = ''
+  configureForm.value.apiBaseUrl = API_BASE_URL
+  showConfigureDialog.value = true
+}
+
+// 打开 BotFather 创建 Bot
+async function openBotFather() {
+  try {
+    await open('https://t.me/BotFather')
+    message.success('已打开 Telegram BotFather')
+  }
+  catch (error) {
+    console.error('打开 BotFather 失败:', error)
+    message.error('打开 BotFather 失败，请手动在 Telegram 中搜索 @BotFather')
+  }
+}
+
+// 自动获取 Chat ID（用于会话配置）
+async function autoGetChatIdForSession() {
+  if (!configureForm.value.botToken.trim()) {
+    message.warning('请先输入 Bot Token')
+    return
+  }
+
+  try {
+    // 定义清理函数数组
+    const cleanupFunctions: (() => void)[] = []
+
+    const unlistenStart = await listen('chat-id-detection-started', () => {
+      message.info('开始监听消息，请向Bot发送任意消息...')
+    })
+    cleanupFunctions.push(unlistenStart)
+
+    const unlistenDetected = await listen('chat-id-detected', (event: any) => {
+      message.success(`检测到Chat ID: ${event.payload.chat_id}`)
+
+      // 自动填入Chat ID到表单
+      configureForm.value.chatId = event.payload.chat_id
+
+      // 清理所有监听器
+      cleanupFunctions.forEach(cleanup => cleanup())
+    })
+    cleanupFunctions.push(unlistenDetected)
+
+    const unlistenTimeout = await listen('chat-id-detection-timeout', () => {
+      message.warning('检测超时，请确保Bot Token正确并向Bot发送消息')
+
+      // 清理所有监听器
+      cleanupFunctions.forEach(cleanup => cleanup())
+    })
+    cleanupFunctions.push(unlistenTimeout)
+
+    // 开始自动获取
+    await invoke('auto_get_chat_id', {
+      botToken: configureForm.value.botToken.trim(),
+    })
+  }
+  catch (error: any) {
+    console.error('启动自动获取 Chat ID 失败:', error)
+    message.error(error || '启动失败')
+  }
+}
+
+// 保存会话配置
+async function saveSessionConfiguration() {
+  if (!configuringSession.value)
+    return
+
+  let botName: string
+  let botToken: string
+  let chatId: string
+  let apiBaseUrl: string | null
+
+  if (configureForm.value.useExistingBot) {
+    // 使用已有 Bot
+    if (!configureForm.value.selectedBotName) {
+      message.warning('请选择一个 Bot')
+      return
+    }
+    const selectedBot = telegramConfig.value.bots.find(b => b.name === configureForm.value.selectedBotName)
+    if (!selectedBot) {
+      message.error('选中的 Bot 不存在')
+      return
+    }
+    botName = selectedBot.name
+    botToken = selectedBot.bot_token
+    chatId = selectedBot.chat_id
+    apiBaseUrl = selectedBot.api_base_url || null
+  }
+  else {
+    // 创建新 Bot
+    if (!configureForm.value.botName.trim() || !configureForm.value.botToken.trim() || !configureForm.value.chatId.trim()) {
+      message.warning('请填写完整信息')
+      return
+    }
+    botName = configureForm.value.botName.trim()
+    botToken = configureForm.value.botToken.trim()
+    chatId = configureForm.value.chatId.trim()
+    apiBaseUrl = configureForm.value.apiBaseUrl === API_BASE_URL ? null : configureForm.value.apiBaseUrl
+  }
+
+  try {
+    if (configureForm.value.useExistingBot) {
+      // 使用已有 Bot：只设置映射
+      await invoke('set_session_bot_mapping', {
+        sessionId: configuringSession.value.session_id,
+        botName,
+      })
+    }
+    else {
+      // 创建新 Bot：创建 Bot 并设置映射
+      await invoke('configure_session_bot', {
+        sessionId: configuringSession.value.session_id,
+        botName,
+        botToken,
+        chatId,
+        apiBaseUrl,
+      })
+    }
+
+    message.success('会话配置成功')
+    showConfigureDialog.value = false
+    configuringSession.value = null
+    await loadPendingSessions()
+    await loadTelegramConfig()
+    await loadSessionMappings()
+  }
+  catch (error: any) {
+    console.error('配置会话失败:', error)
+    message.error(error || '配置会话失败')
+  }
+}
+
+// 忽略待配置会话
+async function ignoreSession(session: PendingSession) {
+  try {
+    await invoke('ignore_pending_session', {
+      sessionId: session.session_id,
+    })
+
+    message.success('已忽略该会话')
+    await loadPendingSessions()
+  }
+  catch (error: any) {
+    console.error('忽略会话失败:', error)
+    message.error(error || '忽略会话失败')
+  }
+}
+
+// 格式化时间
+function formatTime(isoString: string) {
+  const date = new Date(isoString)
+  return date.toLocaleString('zh-CN', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
 }
 
 // 组件挂载时加载配置
 onMounted(() => {
   loadTelegramConfig()
+  loadSessionMappings()
+  loadPendingSessions()
 })
 </script>
 
@@ -193,95 +562,122 @@ onMounted(() => {
         </div>
       </div>
       <div class="flex items-center gap-2">
-        <n-button
-          v-if="!telegramConfig.enabled && (!telegramConfig.bot_token.trim() || !telegramConfig.chat_id.trim())"
-          size="small" type="primary" @click="startSetupWizard"
-        >
-          一键设置
-        </n-button>
-        <n-switch :value="telegramConfig.enabled" size="small" @update:value="toggleTelegramEnabled" />
+        <n-switch v-model:value="telegramConfig.enabled" size="small" @update:value="toggleTelegramEnabled" />
       </div>
     </div>
 
     <!-- 配置项区域 - 条件显示 -->
     <n-collapse-transition :show="telegramConfig.enabled">
       <n-space vertical size="large">
-        <!-- Bot Token设置 -->
+        <!-- Bot 列表 -->
         <div class="pt-4 border-t border-gray-200 dark:border-gray-700">
           <div class="flex items-start">
             <div class="w-1.5 h-1.5 bg-info rounded-full mr-3 mt-2 flex-shrink-0" />
             <div class="flex-1">
-              <div class="text-sm font-medium mb-3 leading-relaxed">
-                Bot Token
-              </div>
-              <div class="text-xs opacity-60 mb-3">
-                从 @BotFather 获取的Bot Token，用于验证Bot身份。不知道如何获取？点击下方"设置指引"查看完整教程
-              </div>
-              <n-space vertical size="small">
-                <n-input
-                  v-model:value="telegramConfig.bot_token" type="text"
-                  placeholder="请输入Bot Token (例如: 123456789:ABCdefGHIjklMNOpqrsTUVwxyz)" size="small"
-                  :disabled="isTesting" @blur="saveTelegramConfig"
-                />
-                <n-button size="small" type="info" @click="startSetupWizard">
-                  📋 设置指引
+              <div class="flex items-center justify-between mb-3">
+                <div>
+                  <div class="text-sm font-medium leading-relaxed">
+                    Bot 配置列表
+                  </div>
+                  <div class="text-xs opacity-60">
+                    管理多个 Telegram Bot，支持为不同对话使用不同的 Bot
+                  </div>
+                </div>
+                <n-button size="small" type="primary" @click="openAddBotDialog">
+                  ➕ 添加 Bot
                 </n-button>
-              </n-space>
-            </div>
-          </div>
-        </div>
+              </div>
 
-        <!-- Chat ID设置 -->
-        <div class="pt-4 border-t border-gray-200 dark:border-gray-700">
-          <div class="flex items-start">
-            <div class="w-1.5 h-1.5 bg-info rounded-full mr-3 mt-2 flex-shrink-0" />
-            <div class="flex-1">
-              <div class="text-sm font-medium mb-3 leading-relaxed">
-                Chat ID
-              </div>
-              <div class="text-xs opacity-60 mb-3">
-                目标聊天的ID，可以是个人聊天或群组聊天的ID。不知道如何获取？点击"详细指引"查看完整教程
-              </div>
-              <n-space vertical size="small">
-                <n-input
-                  v-model:value="telegramConfig.chat_id" type="text"
-                  placeholder="请输入Chat ID (例如: 123456789 或 -123456789)" size="small"
-                  :disabled="isTesting || isDetectingChatId" @blur="saveTelegramConfig"
-                />
-                <n-button
-                  size="small" type="primary" :loading="isDetectingChatId"
-                  :disabled="!telegramConfig.bot_token.trim() || isTesting" @click="autoGetChatId"
+              <!-- Bot 列表 -->
+              <n-space v-if="telegramConfig.bots.length > 0" vertical size="small">
+                <div
+                  v-for="bot in telegramConfig.bots" :key="bot.name"
+                  class="p-3 rounded border border-gray-200 dark:border-gray-700"
                 >
-                  {{ isDetectingChatId ? '监听中...' : '自动获取' }}
-                </n-button>
-                <div v-if="detectedChatInfo" class="text-xs text-success-600 dark:text-success-400">
-                  ✅ 已检测到: {{ detectedChatInfo.chat_title }} ({{ detectedChatInfo.username }})
+                  <div class="flex items-center justify-between">
+                    <div class="flex-1">
+                      <div class="flex items-center gap-2 mb-1">
+                        <span class="text-sm font-medium">{{ bot.name }}</span>
+                        <n-tag v-if="bot.name === telegramConfig.default_bot" size="small" type="success">
+                          默认
+                        </n-tag>
+                      </div>
+                      <div class="text-xs opacity-60">
+                        Token: {{ bot.bot_token.substring(0, 20) }}... | Chat ID: {{ bot.chat_id }}
+                      </div>
+                    </div>
+                    <n-space size="small">
+                      <n-button
+                        v-if="bot.name !== telegramConfig.default_bot"
+                        size="tiny" @click="setDefaultBot(bot.name)"
+                      >
+                        设为默认
+                      </n-button>
+                      <n-button size="tiny" @click="testBotConnection(bot)">
+                        测试
+                      </n-button>
+                      <n-button size="tiny" @click="openEditBotDialog(bot)">
+                        编辑
+                      </n-button>
+                      <n-button size="tiny" type="error" @click="deleteBot(bot.name)">
+                        删除
+                      </n-button>
+                    </n-space>
+                  </div>
                 </div>
               </n-space>
+              <n-empty v-else description="暂无 Bot 配置，点击上方按钮添加" size="small" />
             </div>
           </div>
         </div>
 
-        <!-- API服务器URL设置 -->
-        <div class="pt-4 border-t border-gray-200 dark:border-gray-700">
+        <!-- 待配置会话提示 -->
+        <div v-if="pendingSessions.length > 0" class="pt-4 border-t border-gray-200 dark:border-gray-700">
+          <div class="flex items-start">
+            <div class="w-1.5 h-1.5 bg-warning rounded-full mr-3 mt-2 flex-shrink-0" />
+            <div class="flex-1">
+              <div class="flex items-center justify-between mb-3">
+                <div>
+                  <div class="text-sm font-medium leading-relaxed">
+                    🔔 发现新的工作目录
+                  </div>
+                  <div class="text-xs opacity-60">
+                    检测到 {{ pendingSessions.length }} 个新的工作目录，建议为它们配置专属 Bot
+                  </div>
+                </div>
+                <n-button type="warning" size="small" @click="openPendingSessionsDialog">
+                  立即配置
+                </n-button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- 会话映射管理 -->
+        <div v-if="telegramConfig.bots.length > 0" class="pt-4 border-t border-gray-200 dark:border-gray-700">
           <div class="flex items-start">
             <div class="w-1.5 h-1.5 bg-info rounded-full mr-3 mt-2 flex-shrink-0" />
             <div class="flex-1">
-              <div class="text-sm font-medium mb-3 leading-relaxed">
-                API服务器URL
+              <div class="flex items-center justify-between mb-3">
+                <div>
+                  <div class="text-sm font-medium leading-relaxed">
+                    会话自动映射
+                  </div>
+                  <div class="text-xs opacity-60">
+                    根据工作目录自动选择对应的 Bot，无需手动切换
+                  </div>
+                </div>
+                <n-button size="small" @click="openSessionMappingDialog">
+                  ⚙️ 管理映射
+                </n-button>
               </div>
-              <div class="text-xs opacity-60 mb-3">
-                API服务器地址，支持自定义代理
+
+              <!-- 映射列表预览 -->
+              <div v-if="Object.keys(sessionMappings).length > 0" class="text-xs opacity-60">
+                已配置 {{ Object.keys(sessionMappings).length }} 个会话映射
               </div>
-              <n-space vertical size="small">
-                <n-input
-                  v-model:value="telegramConfig.api_base_url" type="text"
-                  :placeholder="API_BASE_URL" size="small"
-                  :disabled="isTesting" @blur="saveTelegramConfig"
-                />
-              </n-space>
-              <div class="text-xs opacity-60 mt-2">
-                💡 官方: {{ API_EXAMPLES.official }} | 代理: {{ API_EXAMPLES.proxy_example }}
+              <div v-else class="text-xs opacity-60">
+                暂无会话映射，点击"管理映射"添加
               </div>
             </div>
           </div>
@@ -303,178 +699,351 @@ onMounted(() => {
             </div>
             <n-switch
               v-model:value="telegramConfig.hide_frontend_popup" size="small"
-              @update:value="saveTelegramConfig"
+              @update:value="toggleHideFrontendPopup"
             />
           </div>
         </div>
 
-        <!-- 保存并测试按钮 -->
-        <div class="pt-4 border-t border-gray-200 dark:border-gray-700">
-          <div class="flex items-start">
-            <div class="w-1.5 h-1.5 bg-info rounded-full mr-3 mt-2 flex-shrink-0" />
-            <div class="flex-1">
-              <div class="text-sm font-medium mb-3 leading-relaxed">
-                连接测试
-              </div>
-              <div class="text-xs opacity-60 mb-3">
-                保存配置并发送测试消息验证连接
-              </div>
-              <n-button
-                type="primary" size="small" :loading="isTesting"
-                :disabled="!telegramConfig.bot_token.trim() || !telegramConfig.chat_id.trim()" @click="saveAndTest"
-              >
-                {{ isTesting ? '测试中...' : '测试连接' }}
-              </n-button>
-            </div>
-          </div>
-        </div>
       </n-space>
     </n-collapse-transition>
   </n-space>
 
-  <!-- 设置向导模态框 -->
-  <n-modal v-model:show="showSetupWizard" preset="card" title="Telegram Bot 设置向导" style="width: 600px; margin: 0 20px;">
-    <n-steps :current="setupStep" size="small">
-      <n-step title="创建Bot" />
-      <n-step title="获取Token" />
-      <n-step title="获取Chat ID" />
-      <n-step title="完成设置" />
-    </n-steps>
-
-    <div class="mt-6">
-      <!-- 步骤1: 创建Bot -->
-      <div v-if="setupStep === 1" class="space-y-4">
-        <h3 class="text-lg font-medium">
-          第一步：创建Telegram Bot
-        </h3>
-        <div class="space-y-3 text-sm">
-          <p>1. 在Telegram中搜索并打开 <code class="bg-blue-100 dark:bg-blue-800 text-blue-800 dark:text-blue-200 px-2 py-1 rounded font-medium">@BotFather</code></p>
-          <p>2. 发送命令 <code class="bg-green-100 dark:bg-green-800 text-green-800 dark:text-green-200 px-2 py-1 rounded font-medium">/newbot</code></p>
-          <p>3. 按提示输入Bot的名称和用户名</p>
-          <p>4. 创建成功后，BotFather会发送Bot Token给你</p>
+  <!-- Bot 编辑对话框 -->
+  <n-modal v-model:show="showBotDialog" preset="card" :title="editingBot ? '编辑 Bot' : '添加 Bot'" style="width: 600px; margin: 0 20px;">
+    <n-space vertical size="large">
+      <!-- Bot 名称 -->
+      <div>
+        <div class="text-sm font-medium mb-2">
+          Bot 名称
         </div>
-        <n-space justify="end">
-          <n-button @click="closeSetupWizard">
-            取消
-          </n-button>
-          <n-button type="primary" @click="setupStep = 2">
-            下一步
-          </n-button>
-        </n-space>
+        <n-input
+          v-model:value="botForm.name" type="text"
+          placeholder="例如: 工作Bot、个人Bot" size="small"
+        />
+        <div class="text-xs opacity-60 mt-1">
+          用于区分不同的 Bot，建议使用有意义的名称
+        </div>
       </div>
 
-      <!-- 步骤2: 获取Token -->
-      <div v-if="setupStep === 2" class="space-y-4">
-        <h3 class="text-lg font-medium">
-          第二步：输入Bot Token
-        </h3>
-        <div class="space-y-3 text-sm">
-          <p>将BotFather发送给你的Token粘贴到下面：</p>
+      <!-- Bot Token -->
+      <div>
+        <div class="text-sm font-medium mb-2">
+          Bot Token
+        </div>
+        <n-input
+          v-model:value="botForm.bot_token" type="text"
+          placeholder="例如: 123456789:ABCdefGHIjklMNOpqrsTUVwxyz" size="small"
+        />
+        <div class="text-xs opacity-60 mt-1">
+          从 @BotFather 获取的 Bot Token
+        </div>
+      </div>
+
+      <!-- Chat ID -->
+      <div>
+        <div class="text-sm font-medium mb-2">
+          Chat ID
+        </div>
+        <n-input
+          v-model:value="botForm.chat_id" type="text"
+          placeholder="例如: 123456789" size="small"
+        />
+        <n-button
+          size="small" type="primary" :loading="isDetectingChatId"
+          :disabled="!botForm.bot_token.trim()" @click="autoGetChatIdForBot"
+          class="mt-2"
+        >
+          {{ isDetectingChatId ? '监听中...' : '自动获取 Chat ID' }}
+        </n-button>
+        <div v-if="detectedChatInfo" class="text-xs text-success-600 dark:text-success-400 mt-1">
+          ✅ 已检测到: {{ detectedChatInfo.chat_id }}
+        </div>
+        <div class="text-xs opacity-60 mt-1">
+          目标聊天的 ID，点击"自动获取"后向 Bot 发送消息即可
+        </div>
+      </div>
+
+      <!-- API 基础 URL -->
+      <div>
+        <div class="text-sm font-medium mb-2">
+          API 基础 URL
+        </div>
+        <n-input
+          v-model:value="botForm.api_base_url" type="text"
+          :placeholder="API_BASE_URL" size="small"
+        />
+        <div class="text-xs opacity-60 mt-1">
+          Telegram API 地址，默认使用官方 API，也可配置代理
+        </div>
+      </div>
+    </n-space>
+
+    <template #footer>
+      <n-space justify="end">
+        <n-button @click="showBotDialog = false">
+          取消
+        </n-button>
+        <n-button type="primary" @click="saveBotConfig">
+          保存
+        </n-button>
+      </n-space>
+    </template>
+  </n-modal>
+
+  <!-- 会话映射管理对话框 -->
+  <n-modal v-model:show="showSessionMappingDialog" preset="card" title="会话自动映射管理" style="width: 700px; margin: 0 20px;">
+    <n-space vertical size="large">
+      <!-- 说明 -->
+      <n-alert type="info" title="自动映射说明">
+        <div class="text-sm space-y-2">
+          <p>• 系统会根据当前工作目录自动选择对应的 Bot</p>
+          <p>• 例如：在 <code>/Users/you/project-a</code> 目录下使用寸止时，会自动使用"项目A Bot"</p>
+          <p>• 如果没有配置映射，则使用默认 Bot</p>
+        </div>
+      </n-alert>
+
+      <!-- 映射列表 -->
+      <div>
+        <div class="text-sm font-medium mb-3">
+          当前映射 ({{ Object.keys(sessionMappings).length }})
+        </div>
+        <n-space v-if="Object.keys(sessionMappings).length > 0" vertical size="small">
+          <div
+            v-for="(botName, sessionId) in sessionMappings" :key="sessionId"
+            class="p-3 rounded border border-gray-200 dark:border-gray-700 flex items-center justify-between"
+          >
+            <div class="flex-1 min-w-0">
+              <div class="text-sm font-medium truncate">
+                {{ sessionId }}
+              </div>
+              <div class="text-xs opacity-60 mt-1">
+                → {{ botName }}
+              </div>
+            </div>
+            <n-button size="tiny" type="error" @click="removeSessionMapping(sessionId)">
+              删除
+            </n-button>
+          </div>
+        </n-space>
+        <n-empty v-else description="暂无会话映射" size="small" />
+      </div>
+
+      <!-- 添加新映射 -->
+      <div class="pt-4 border-t border-gray-200 dark:border-gray-700">
+        <div class="text-sm font-medium mb-3">
+          添加新映射
+        </div>
+        <n-space vertical size="small">
           <n-input
-            v-model:value="telegramConfig.bot_token" type="text"
-            placeholder="例如: 123456789:ABCdefGHIjklMNOpqrsTUVwxyz" size="small"
+            v-model:value="newSessionId" type="text"
+            placeholder="会话 ID（例如：/Users/you/project-a）" size="small"
           />
-        </div>
-        <n-space justify="end">
-          <n-button @click="setupStep = 1">
-            上一步
-          </n-button>
-          <n-button type="primary" :disabled="!telegramConfig.bot_token.trim()" @click="setupStep = 3">
-            下一步
+          <n-select
+            v-model:value="newSessionBotName"
+            :options="telegramConfig.bots.map(bot => ({ label: bot.name, value: bot.name }))"
+            placeholder="选择 Bot" size="small"
+          />
+          <n-button
+            type="primary" size="small"
+            :disabled="!newSessionId.trim() || !newSessionBotName"
+            @click="addNewSessionMapping"
+          >
+            添加映射
           </n-button>
         </n-space>
       </div>
+    </n-space>
 
-      <!-- 步骤3: 获取Chat ID -->
-      <div v-if="setupStep === 3" class="space-y-4">
-        <h3 class="text-lg font-medium">
-          第三步：获取Chat ID
-        </h3>
-        <div class="space-y-2 text-sm">
-          <n-card size="small">
-            <h4 class="font-medium mb-2">
-              方式一：自动获取（推荐）
-            </h4>
-            <n-button
-              size="small" type="primary" :loading="isDetectingChatId"
-              :disabled="!telegramConfig.bot_token.trim()" @click="autoGetChatId"
-            >
-              {{ isDetectingChatId ? '监听中，请发送消息...' : '开始自动获取' }}
-            </n-button>
-            <div v-if="detectedChatInfo" class="mt-2 text-sm text-success-600 dark:text-success-400">
-              ✅ 检测成功: {{ detectedChatInfo.chat_id }}
+    <template #footer>
+      <n-space justify="end">
+        <n-button @click="showSessionMappingDialog = false">
+          关闭
+        </n-button>
+      </n-space>
+    </template>
+  </n-modal>
+
+  <!-- 待配置会话对话框 -->
+  <n-modal v-model:show="showPendingSessionsDialog" preset="card" title="待配置的工作目录" style="width: 800px; margin: 0 20px;">
+    <n-space vertical size="large">
+      <!-- 说明 -->
+      <n-alert type="info" title="自动识别说明">
+        <div class="text-sm space-y-2">
+          <p>• 系统已自动识别到以下工作目录使用了寸止工具</p>
+          <p>• 建议为每个目录配置专属的 Telegram Bot，实现消息隔离</p>
+          <p>• 如果不需要单独配置，可以点击"忽略"使用默认 Bot</p>
+        </div>
+      </n-alert>
+
+      <!-- 待配置会话列表 -->
+      <div>
+        <div class="text-sm font-medium mb-3">
+          待配置目录 ({{ pendingSessions.length }})
+        </div>
+        <n-space v-if="pendingSessions.length > 0" vertical size="small">
+          <div
+            v-for="session in pendingSessions" :key="session.session_id"
+            class="p-4 rounded border border-gray-200 dark:border-gray-700"
+          >
+            <div class="flex items-start justify-between">
+              <div class="flex-1 min-w-0">
+                <div class="text-sm font-medium truncate mb-2">
+                  📁 {{ session.session_id }}
+                </div>
+                <div class="text-xs opacity-60 space-y-1">
+                  <div>首次使用：{{ formatTime(session.first_seen) }}</div>
+                  <div>最后使用：{{ formatTime(session.last_seen) }}</div>
+                  <div>使用次数：{{ session.request_count }} 次</div>
+                </div>
+              </div>
+              <n-space size="small">
+                <n-button size="small" type="primary" @click="startConfigureSession(session)">
+                  配置 Bot
+                </n-button>
+                <n-button size="small" @click="ignoreSession(session)">
+                  忽略
+                </n-button>
+              </n-space>
             </div>
-          </n-card>
+          </div>
+        </n-space>
+        <n-empty v-else description="暂无待配置的会话" size="small" />
+      </div>
+    </n-space>
 
-          <n-card size="small">
-            <h4 class="font-medium mb-2">
-              方式二：手动获取
-            </h4>
-            <div class="text-sm space-y-2">
-              <div class="p-2 rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800">
-                <code class="text-xs break-all text-gray-700 dark:text-gray-300">
-                  {{ telegramConfig.api_base_url }}{{ telegramConfig.bot_token || 'YOUR_BOT_TOKEN' }}/getUpdates
-                </code>
+    <template #footer>
+      <n-space justify="end">
+        <n-button @click="showPendingSessionsDialog = false">
+          关闭
+        </n-button>
+      </n-space>
+    </template>
+  </n-modal>
+
+  <!-- 配置会话 Bot 对话框 -->
+  <n-modal v-model:show="showConfigureDialog" preset="card" title="配置专属 Bot" style="width: 700px; margin: 0 20px;">
+    <n-space vertical size="large">
+      <!-- 会话信息 -->
+      <n-alert v-if="configuringSession" type="info">
+        <div class="text-sm">
+          <div class="font-medium mb-1">工作目录</div>
+          <div class="opacity-80">{{ configuringSession.session_id }}</div>
+        </div>
+      </n-alert>
+
+      <!-- 选择 Bot 方式 -->
+      <n-radio-group v-model:value="configureForm.useExistingBot">
+        <n-space>
+          <n-radio :value="false">创建新 Bot</n-radio>
+          <n-radio :value="true" :disabled="telegramConfig.bots.length === 0">
+            使用已有 Bot
+            <span v-if="telegramConfig.bots.length === 0" class="text-xs opacity-60">(暂无可用 Bot)</span>
+          </n-radio>
+        </n-space>
+      </n-radio-group>
+
+      <!-- 使用已有 Bot -->
+      <template v-if="configureForm.useExistingBot">
+        <n-alert v-if="telegramConfig.bots.length === 0" type="warning">
+          暂无可用的 Bot，请先在"Bot 管理"中添加 Bot
+        </n-alert>
+        <div v-else>
+          <div class="text-sm font-medium mb-3">选择 Bot</div>
+          <n-radio-group v-model:value="configureForm.selectedBotName">
+            <n-space vertical>
+              <n-radio
+                v-for="bot in telegramConfig.bots"
+                :key="bot.name"
+                :value="bot.name"
+              >
+                <div class="flex items-center">
+                  <span class="font-medium">{{ bot.name }}</span>
+                  <span v-if="bot.is_default" class="ml-2 text-xs opacity-60">(默认)</span>
+                </div>
+              </n-radio>
+            </n-space>
+          </n-radio-group>
+
+          <!-- 显示选中的 Bot 信息 -->
+          <n-alert v-if="configureForm.selectedBotName" type="info" class="mt-3">
+            <div class="text-sm">
+              <div class="font-medium mb-1">已选择 Bot: {{ configureForm.selectedBotName }}</div>
+              <div class="opacity-80 text-xs">
+                该会话的消息将发送到此 Bot
               </div>
             </div>
+          </n-alert>
+        </div>
+      </template>
+
+      <!-- 创建新 Bot -->
+      <div v-else>
+        <!-- 创建 Bot 指引 -->
+        <n-alert type="success" title="📝 创建 Bot 步骤">
+          <div class="text-sm space-y-2">
+            <div class="flex items-center justify-between">
+              <div class="flex-1">
+                <p class="font-medium mb-1">1. 打开 Telegram，找到 @BotFather</p>
+                <p class="opacity-80">2. 发送 <code>/newbot</code> 命令</p>
+                <p class="opacity-80">3. 按提示设置 Bot 名称和用户名</p>
+                <p class="opacity-80">4. 复制获得的 Bot Token</p>
+              </div>
+              <n-button type="success" size="small" @click="openBotFather">
+                打开 BotFather
+              </n-button>
+            </div>
+          </div>
+        </n-alert>
+
+        <!-- Bot 配置表单 -->
+        <n-form label-placement="left" label-width="100">
+          <n-form-item label="Bot 名称">
+            <n-input v-model:value="configureForm.botName" placeholder="例如：项目A Bot" />
+          </n-form-item>
+
+        <n-form-item label="Bot Token">
+          <n-input-group>
             <n-input
-              v-model:value="telegramConfig.chat_id" type="text" placeholder="手动输入Chat ID" size="small"
-              class="mt-2"
+              v-model:value="configureForm.botToken" type="password"
+              show-password-on="click" placeholder="从 @BotFather 获取的 Token"
+              style="flex: 1;"
             />
-          </n-card>
-        </div>
-        <n-space justify="end">
-          <n-button @click="setupStep = 2">
-            上一步
-          </n-button>
-          <n-button type="primary" :disabled="!telegramConfig.chat_id.trim()" @click="setupStep = 4">
-            下一步
-          </n-button>
-        </n-space>
-      </div>
+          </n-input-group>
+        </n-form-item>
 
-      <!-- 步骤4: 完成设置 -->
-      <div v-if="setupStep === 4" class="space-y-4">
-        <h3 class="text-lg font-medium">
-          第四步：完成设置
-        </h3>
-        <div class="space-y-2 text-sm">
-          <div>
-            <h4 class="font-medium mb-2">
-              配置确认
-            </h4>
-            <n-card size="small" class="bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700">
-              <div class="space-y-1 text-sm">
-                <div class="text-gray-700 dark:text-gray-300">
-                  <span class="font-medium">Bot Token:</span>
-                  <code class="ml-2 text-gray-600 dark:text-gray-400">{{ telegramConfig.bot_token.substring(0, 20) }}...</code>
-                </div>
-                <div class="text-gray-700 dark:text-gray-300">
-                  <span class="font-medium">Chat ID:</span>
-                  <code class="ml-2 text-gray-600 dark:text-gray-400">{{ telegramConfig.chat_id }}</code>
-                </div>
-              </div>
-            </n-card>
-          </div>
-
-          <div>
-            <h4 class="font-medium mb-2">
-              测试连接
-            </h4>
-            <n-button type="primary" size="small" :loading="isTesting" @click="saveAndTest">
-              {{ isTesting ? '测试中...' : '测试连接' }}
+        <n-form-item label="Chat ID">
+          <n-input-group>
+            <n-input
+              v-model:value="configureForm.chatId"
+              placeholder="Telegram 聊天 ID" style="flex: 1;"
+            />
+            <n-button type="primary" @click="autoGetChatIdForSession">
+              自动获取
             </n-button>
-          </div>
-        </div>
-        <n-space justify="end">
-          <n-button @click="setupStep = 3">
-            上一步
-          </n-button>
-          <n-button type="primary" @click="closeSetupWizard">
-            完成
-          </n-button>
-        </n-space>
+          </n-input-group>
+          <template #feedback>
+            <div class="text-xs opacity-60 mt-1">
+              点击"自动获取"后，在 Telegram 中向 Bot 发送任意消息
+            </div>
+          </template>
+        </n-form-item>
+
+          <n-form-item label="API 基础 URL">
+            <n-input v-model:value="configureForm.apiBaseUrl" placeholder="默认使用官方 API" />
+          </n-form-item>
+        </n-form>
       </div>
-    </div>
+    </n-space>
+
+    <template #footer>
+      <n-space justify="end">
+        <n-button @click="showConfigureDialog = false">
+          取消
+        </n-button>
+        <n-button type="primary" @click="saveSessionConfiguration">
+          保存配置
+        </n-button>
+      </n-space>
+    </template>
   </n-modal>
 </template>

--- a/src/frontend/composables/useMcpHandler.ts
+++ b/src/frontend/composables/useMcpHandler.ts
@@ -82,8 +82,12 @@ export function useMcpHandler() {
           message: request.message,
           predefinedOptions: request.predefined_options || [],
           isMarkdown: request.is_markdown || false,
+          botName: request.bot_name || null,
+          sessionId: request.session_id || null,
         })
         console.log('✅ Telegram同步启动成功')
+        console.log('  - session_id:', request.session_id)
+        console.log('  - bot_name:', request.bot_name)
       }
     }
     catch (error) {
@@ -97,12 +101,30 @@ export function useMcpHandler() {
   async function checkMcpMode() {
     try {
       const args = await invoke('get_cli_args')
+      console.log('📋 CLI args:', args)
 
       if (args && (args as any).mcp_request) {
         // 读取MCP请求文件
         const content = await invoke('read_mcp_request', { filePath: (args as any).mcp_request })
+        console.log('📄 MCP request content:', content)
 
         if (content) {
+          // 记录会话（如果有 session_id）
+          const sessionId = (content as any).session_id
+          if (sessionId) {
+            try {
+              console.log('🔄 开始记录会话:', sessionId)
+              await invoke('record_session', { sessionId })
+              console.log('✅ 会话已记录:', sessionId)
+            }
+            catch (error) {
+              console.error('❌ 记录会话失败:', error)
+            }
+          }
+          else {
+            console.warn('⚠️ 请求中没有 session_id')
+          }
+
           await showMcpDialog(content)
         }
         return { isMcp: true, mcpContent: content }

--- a/src/frontend/types/popup.d.ts
+++ b/src/frontend/types/popup.d.ts
@@ -5,6 +5,8 @@ export interface McpRequest {
   message: string
   predefined_options?: string[]
   is_markdown?: boolean
+  session_id?: string
+  bot_name?: string
 }
 
 // 自定义prompt类型定义

--- a/src/rust/app/builder.rs
+++ b/src/rust/app/builder.rs
@@ -101,9 +101,20 @@ pub fn build_tauri_app() -> Builder<tauri::Wry> {
             // Telegram 命令
             get_telegram_config,
             set_telegram_config,
+            record_session,
             test_telegram_connection_cmd,
             auto_get_chat_id,
             start_telegram_sync,
+            add_telegram_bot,
+            remove_telegram_bot,
+            update_telegram_bot,
+            set_default_telegram_bot,
+            set_session_bot_mapping,
+            remove_session_bot_mapping,
+            get_session_bot_mappings,
+            get_pending_sessions,
+            configure_session_bot,
+            ignore_pending_session,
 
             // 系统命令
             open_external_url,

--- a/src/rust/app/cli.rs
+++ b/src/rust/app/cli.rs
@@ -16,8 +16,14 @@ pub fn handle_cli_args() -> Result<()> {
         // 单参数：帮助或版本
         2 => {
             match args[1].as_str() {
-                "--help" | "-h" => print_help(),
-                "--version" | "-v" => print_version(),
+                "--help" | "-h" => {
+                    print_help();
+                    std::process::exit(0);
+                }
+                "--version" | "-v" => {
+                    print_version();
+                    std::process::exit(0);
+                }
                 _ => {
                     eprintln!("未知参数: {}", args[1]);
                     print_help();
@@ -42,6 +48,9 @@ pub fn handle_cli_args() -> Result<()> {
 
 /// 处理MCP请求
 fn handle_mcp_request(request_file: &str) -> Result<()> {
+    // 先记录会话信息（无论是哪种模式）
+    record_session_from_request(request_file);
+
     // 检查Telegram配置，决定是否启用纯Telegram模式
     match load_standalone_telegram_config() {
         Ok(telegram_config) => {
@@ -68,8 +77,58 @@ fn handle_mcp_request(request_file: &str) -> Result<()> {
     Ok(())
 }
 
+/// 从请求文件中记录会话信息
+fn record_session_from_request(request_file: &str) {
+    use crate::config::{load_standalone_config, save_standalone_config};
+    use crate::mcp::types::PopupRequest;
+
+    log_important!(info, "开始记录会话，请求文件: {}", request_file);
+
+    // 读取请求文件
+    match std::fs::read_to_string(request_file) {
+        Ok(request_json) => {
+            log_important!(info, "成功读取请求文件");
+            match serde_json::from_str::<PopupRequest>(&request_json) {
+                Ok(request) => {
+                    log_important!(info, "成功解析请求，session_id: {:?}", request.session_id);
+                    // 如果请求中包含 session_id，记录会话
+                    if let Some(session_id) = request.session_id {
+                        match load_standalone_config() {
+                            Ok(mut app_config) => {
+                                log_important!(info, "成功加载配置，开始记录会话");
+                                app_config.telegram_config.record_session_request(&session_id);
+                                // 保存配置
+                                match save_standalone_config(&app_config) {
+                                    Ok(_) => {
+                                        log_important!(info, "✅ 已记录会话: {}", session_id);
+                                    }
+                                    Err(e) => {
+                                        log_important!(warn, "保存会话记录失败: {}", e);
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                log_important!(warn, "加载配置失败: {}", e);
+                            }
+                        }
+                    } else {
+                        log_important!(warn, "请求中没有 session_id");
+                    }
+                }
+                Err(e) => {
+                    log_important!(warn, "解析请求失败: {}", e);
+                }
+            }
+        }
+        Err(e) => {
+            log_important!(warn, "读取请求文件失败: {}", e);
+        }
+    }
+}
+
 /// 显示帮助信息
 fn print_help() {
+    use std::io::{self, Write};
     println!("寸止 - 智能代码审查工具");
     println!();
     println!("用法:");
@@ -77,9 +136,12 @@ fn print_help() {
     println!("  等一下 --mcp-request <文件>  处理 MCP 请求");
     println!("  等一下 --help             显示此帮助信息");
     println!("  等一下 --version          显示版本信息");
+    let _ = io::stdout().flush();
 }
 
 /// 显示版本信息
 fn print_version() {
+    use std::io::{self, Write};
     println!("寸止 v{}", env!("CARGO_PKG_VERSION"));
+    let _ = io::stdout().flush();
 }

--- a/src/rust/mcp/server.rs
+++ b/src/rust/mcp/server.rs
@@ -102,6 +102,10 @@ impl ServerHandler for ZhiServer {
                 "is_markdown": {
                     "type": "boolean",
                     "description": "消息是否为Markdown格式，默认为true"
+                },
+                "working_directory": {
+                    "type": "string",
+                    "description": "当前工作目录（可选），用于会话识别。AI应该传递当前项目的根目录路径"
                 }
             },
             "required": ["message"]
@@ -177,6 +181,10 @@ impl ServerHandler for ZhiServer {
                 let arguments_value = request.arguments
                     .map(serde_json::Value::Object)
                     .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
+
+                // 调试：记录原始参数
+                log_important!(info, "🔍 MCP 服务器收到 zhi 请求");
+                log_important!(info, "🔍 原始参数: {}", serde_json::to_string_pretty(&arguments_value).unwrap_or_default());
 
                 let zhi_request: ZhiRequest = serde_json::from_value(arguments_value)
                     .map_err(|e| McpError::invalid_params(format!("参数解析失败: {}", e), None))?;

--- a/src/rust/mcp/tools/interaction/mcp.rs
+++ b/src/rust/mcp/tools/interaction/mcp.rs
@@ -15,6 +15,58 @@ impl InteractionTool {
     pub async fn zhi(
         request: ZhiRequest,
     ) -> Result<CallToolResult, McpError> {
+        use crate::log_important;
+
+        // 调试：将请求参数写入临时文件
+        let debug_file = std::env::temp_dir().join("cunzhi_zhi_request_debug.json");
+        if let Ok(json) = serde_json::to_string_pretty(&request) {
+            let _ = std::fs::write(&debug_file, json);
+            log_important!(info, "🔍 请求参数已写入: {:?}", debug_file);
+        }
+
+        // 尝试获取会话 ID（工作目录）
+        // 优先级：working_directory 参数 > CUNZHI_SESSION_ID > PWD > current_dir > 生成唯一ID
+        let session_id = request.working_directory
+            .clone()
+            .or_else(|| std::env::var("CUNZHI_SESSION_ID").ok())
+            .or_else(|| std::env::var("PWD").ok())
+            .or_else(|| {
+                std::env::current_dir()
+                    .ok()
+                    .and_then(|path| path.to_str().map(|s| s.to_string()))
+            })
+            .or_else(|| {
+                // 如果无法获取工作目录，生成一个基于时间戳的唯一会话ID
+                use std::time::{SystemTime, UNIX_EPOCH};
+                let timestamp = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .ok()?
+                    .as_secs();
+                let random_suffix = std::process::id(); // 使用进程ID作为随机后缀
+                Some(format!("session_{}_pid_{}", timestamp, random_suffix))
+            })
+            .map(|s| {
+                // 标准化路径：移除末尾斜杠
+                s.trim_end_matches('/').to_string()
+            });
+
+        // 调试信息
+        log_important!(info, "🔍 working_directory 参数: {:?}", request.working_directory);
+        log_important!(info, "🔍 CUNZHI_SESSION_ID 环境变量: {:?}", std::env::var("CUNZHI_SESSION_ID").ok());
+        log_important!(info, "🔍 PWD 环境变量: {:?}", std::env::var("PWD").ok());
+        log_important!(info, "🔍 current_dir(): {:?}", std::env::current_dir().ok());
+        log_important!(info, "🔍 最终 session_id: {:?}", session_id);
+
+        if let Some(ref sid) = session_id {
+            if sid.starts_with("session_") {
+                log_important!(info, "使用生成的会话ID: {}", sid);
+            } else {
+                log_important!(info, "使用工作目录作为会话ID: {}", sid);
+            }
+        } else {
+            log_important!(warn, "⚠️ 没有会话ID");
+        }
+
         let popup_request = PopupRequest {
             id: generate_request_id(),
             message: request.message,
@@ -23,8 +75,12 @@ impl InteractionTool {
             } else {
                 Some(request.predefined_options)
             },
+            bot_name: None, // 使用默认 bot 或根据 session_id 映射
+            session_id: session_id.clone(),     // 传递会话 ID
             is_markdown: request.is_markdown,
         };
+
+        log_important!(info, "📤 发送 PopupRequest，session_id: {:?}", popup_request.session_id);
 
         match create_tauri_popup(&popup_request) {
             Ok(response) => {

--- a/src/rust/mcp/types.rs
+++ b/src/rust/mcp/types.rs
@@ -1,7 +1,7 @@
 use chrono;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct ZhiRequest {
     #[schemars(description = "要显示给用户的消息")]
     pub message: String,
@@ -11,6 +11,9 @@ pub struct ZhiRequest {
     #[schemars(description = "消息是否为Markdown格式，默认为true")]
     #[serde(default = "default_is_markdown")]
     pub is_markdown: bool,
+    #[schemars(description = "当前工作目录（强烈建议传递），用于会话识别和多Bot路由。格式：path:branch（例如：/Users/username/project:main）或 path（非Git仓库）。AI应该先获取当前Git分支（使用 git branch --show-current），然后构建 'path:branch' 格式的working_directory。如果不是Git仓库或无法获取分支，则只传递路径。这样可以确保同一目录的不同分支使用不同的Bot。")]
+    #[serde(default)]
+    pub working_directory: Option<String>,
 }
 
 fn default_is_markdown() -> bool {
@@ -51,6 +54,10 @@ pub struct PopupRequest {
     pub message: String,
     pub predefined_options: Option<Vec<String>>,
     pub is_markdown: bool,
+    #[serde(default)]
+    pub bot_name: Option<String>, // 可选的 Telegram Bot 名称
+    #[serde(default)]
+    pub session_id: Option<String>, // 可选的会话 ID，用于自动选择 bot
 }
 
 /// 新的结构化响应数据格式

--- a/test_telegram_request.json
+++ b/test_telegram_request.json
@@ -1,0 +1,11 @@
+{
+  "id": "test-telegram-integration",
+  "message": "# Telegram 集成测试\n\n这是一条测试消息，用于验证 Telegram Bot 集成是否正常工作。\n\n如果您在 Telegram 中看到这条消息，说明配置成功！",
+  "predefined_options": [
+    "配置成功 ✅",
+    "需要调整",
+    "测试其他功能"
+  ],
+  "is_markdown": true
+}
+


### PR DESCRIPTION
- 支持配置和管理多个Telegram Bot
- 实现基于working_directory的自动Bot路由
- 支持Git分支映射（path:branch格式）

这个pr是为了解决这样一个问题：当我需要同时进行多个项目或者同一项目的不同分支的开发时，所有的消息都会转发到同一个telegram bot，导致通过telegram回复消息时可能存在混淆和意外的错误，所以我增加了多个telegram bot的配置，然后支持通过工作目录（项目的根目录+对应的分支名）来映射到不同的bot，这样就不会出现之前的问题了。